### PR TITLE
fix: tighten backend cors configuration

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -14,11 +14,11 @@ app = FastAPI(title="Admin Panel Mock Backend API")
 
 # Define allowed origins for CORS (Cross-Origin Resource Sharing)
 # MUST include '*' for development, or the specific address where the React app runs.
+# Allowed CORS origins ограничены доменами фронтенда для корректной работы cookies
 origins = [
     "http://localhost",
     "http://localhost:3000",  # Common React development port
     "http://localhost:8080",
-    "*"  # Allowing all origins for simple testing/Canvas environment
 ]
 
 # Adding CORS middleware

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic
 python-jose[jwt]
 asyncio
+python-multipart


### PR DESCRIPTION
## Summary
- restrict backend CORS origins to the known frontend development hosts so cookies can be sent securely
- add python-multipart dependency to ensure FastAPI form endpoints load without runtime errors

## Testing
- uvicorn backend_main:app --reload --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68da6b43d088832f8c3ca4e052d4f6ca