### PR TITLE
chore: remove asyncio dependency from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ fastapi
 uvicorn
 pydantic
 python-jose[jwt]
-asyncio
 python-multipart


### PR DESCRIPTION
## Summary
- remove the asyncio dependency from the Python requirements since it is provided by the standard library
- verify that installing the requirements set succeeds without asyncio being listed

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68da6ed626b4832fad35e1bcf50e5ef9