### PR TITLE
feat: implement server-side product filters and sorting

### DIFF
--- a/backend_main.py
+++ b/backend_main.py
@@ -1,0 +1,401 @@
+"""Compact FastAPI backend for product filtering and sorting demo."""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import datetime, timedelta
+from typing import Any, Iterable
+
+from fastapi import Body, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="FastAPI CRUD Booster", version="0.6.1")
+
+
+class Product(BaseModel):
+    """Public product DTO."""
+
+    id: int
+    title: str
+    category: str
+    price: float
+    stock: int
+    available: bool
+    description: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProductCreate(BaseModel):
+    """Payload for product creation."""
+
+    title: str = Field(..., min_length=1)
+    category: str = Field(..., min_length=1)
+    price: float = Field(..., ge=0)
+    stock: int = Field(..., ge=0)
+    available: bool = True
+    description: str | None = None
+
+
+class ProductUpdate(BaseModel):
+    """Patch payload."""
+
+    title: str | None = Field(None, min_length=1)
+    category: str | None = Field(None, min_length=1)
+    price: float | None = Field(None, ge=0)
+    stock: int | None = Field(None, ge=0)
+    available: bool | None = None
+    description: str | None = None
+
+
+class PaginatedProducts(BaseModel):
+    """Paginated response wrapper."""
+
+    items: list[Product]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+    sort: str
+    filters: list[dict[str, Any]]
+    q: str | None = None
+
+
+FIELD_META = {
+    "id": {"type": int, "ops": {"eq", "neq", "gt", "gte", "lt", "lte", "between", "in"}},
+    "title": {"type": str, "ops": {"eq", "neq", "contains", "startswith", "endswith", "in"}},
+    "category": {"type": str, "ops": {"eq", "neq", "contains", "startswith", "endswith", "in"}},
+    "price": {"type": float, "ops": {"eq", "neq", "gt", "gte", "lt", "lte", "between", "in"}},
+    "stock": {"type": int, "ops": {"eq", "neq", "gt", "gte", "lt", "lte", "between", "in"}},
+    "available": {"type": bool, "ops": {"eq", "neq", "istrue", "isfalse"}},
+    "description": {"type": str, "ops": {"eq", "neq", "contains", "startswith", "endswith", "isnull"}},
+    "created_at": {"type": datetime, "ops": {"eq", "neq", "gt", "gte", "lt", "lte", "between"}},
+    "updated_at": {"type": datetime, "ops": {"eq", "neq", "gt", "gte", "lt", "lte", "between"}},
+}
+SEARCH_FIELDS = ("title", "description", "category")
+DEFAULT_SORT = "id,asc"
+
+_DATA: list[dict[str, Any]] = []
+_LOCK = threading.Lock()
+_NEXT_ID = 1
+
+
+class ConnectionManager:
+    """Tracks WebSocket subscribers."""
+
+    def __init__(self) -> None:
+        self._clients: set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._clients.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._clients.discard(websocket)
+
+    async def broadcast(self, payload: dict[str, Any]) -> None:
+        message = json.dumps(payload, default=_jsonify)
+        stale: list[WebSocket] = []
+        async with self._lock:
+            for client in self._clients:
+                try:
+                    await client.send_text(message)
+                except Exception:
+                    stale.append(client)
+        for client in stale:
+            await self.disconnect(client)
+
+
+manager = ConnectionManager()
+
+
+def _jsonify(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Unsupported type: {type(value)!r}")
+
+
+def _seed() -> None:
+    """Fill the in-memory dataset."""
+
+    global _DATA, _NEXT_ID
+    base = datetime.utcnow() - timedelta(days=30)
+    _DATA = [
+        {
+            "id": idx,
+            "title": f"Product {idx}",
+            "category": "Electronics" if idx % 2 else "Accessories",
+            "price": round(59 + idx * 3.2, 2),
+            "stock": 120 - idx * 2,
+            "available": idx % 3 != 0,
+            "description": None if idx % 5 == 0 else f"SKU {idx}",
+            "created_at": base + timedelta(days=idx),
+            "updated_at": base + timedelta(days=idx // 2),
+        }
+        for idx in range(1, 26)
+    ]
+    _NEXT_ID = len(_DATA) + 1
+
+
+def _error(message: str, *, details: dict[str, Any] | None = None) -> HTTPException:
+    payload = {"error_code": "invalid_request", "message": message}
+    if details:
+        payload["details"] = details
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=payload)
+
+
+def _coerce(value: Any, target: type) -> Any:
+    if target is bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.lower() in {"true", "1", "yes", "да"}:
+            return True
+        if isinstance(value, str) and value.lower() in {"false", "0", "no", "нет"}:
+            return False
+        raise _error("Неверное булево значение", details={"value": value})
+    if target is datetime:
+        try:
+            return value if isinstance(value, datetime) else datetime.fromisoformat(str(value))
+        except ValueError as exc:
+            raise _error("Некорректная дата", details={"value": value}) from exc
+    try:
+        return target(value)
+    except (TypeError, ValueError) as exc:
+        raise _error("Не удалось привести значение", details={"value": value, "type": target.__name__}) from exc
+
+
+def _parse_filter(field: str, operator: str, raw: Any) -> dict[str, Any]:
+    meta = FIELD_META.get(field)
+    if not meta:
+        raise _error("Неизвестное поле", details={"field": field})
+    operator = operator.lower()
+    if operator not in meta["ops"]:
+        raise _error("Оператор не поддерживается", details={"field": field, "operator": operator})
+    target = meta["type"]
+    if operator == "between":
+        if isinstance(raw, str):
+            raw = [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+        if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+            raise _error("between ожидает два значения", details={"field": field})
+        value = tuple(_coerce(item, target) for item in raw)
+    elif operator == "in":
+        if isinstance(raw, str):
+            raw = [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+        if not isinstance(raw, Iterable) or not raw:
+            raise _error("in ожидает непустой список", details={"field": field})
+        value = [_coerce(item, target) for item in raw]
+    elif operator in {"istrue", "isfalse"}:
+        value = operator == "istrue"
+    elif operator == "isnull":
+        value = None
+    else:
+        value = _coerce(raw, target)
+    return {"field": field, "operator": operator, "value": value}
+
+
+def _normalize_filters(filters: str | None, field: str | None, operator: str | None, value: str | None) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    if filters:
+        try:
+            raw_filters = json.loads(filters)
+        except json.JSONDecodeError as exc:
+            raise _error("Не удалось распарсить filters", details={"filters": filters}) from exc
+        raw_filters = raw_filters if isinstance(raw_filters, list) else [raw_filters]
+        for item in raw_filters:
+            if not isinstance(item, dict) or not {"field", "operator", "value"}.issubset(item):
+                raise _error("Каждый фильтр должен содержать field/operator/value", details={"filter": item})
+            normalized.append(_parse_filter(item["field"], item["operator"], item["value"]))
+    if field and operator:
+        direct = value
+        if operator.lower() == "between" and isinstance(value, str):
+            direct = [chunk.strip() for chunk in value.split(",") if chunk.strip()]
+        normalized.append(_parse_filter(field, operator, direct))
+    return normalized
+
+
+def _apply_filters(items: list[dict[str, Any]], filters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not filters:
+        return items
+
+    def match(row: dict[str, Any], flt: dict[str, Any]) -> bool:
+        actual = row.get(flt["field"])
+        op = flt["operator"]
+        expected = flt["value"]
+        if op == "eq":
+            return actual == expected
+        if op == "neq":
+            return actual != expected
+        if op == "contains":
+            return isinstance(actual, str) and isinstance(expected, str) and expected.lower() in actual.lower()
+        if op == "startswith":
+            return isinstance(actual, str) and isinstance(expected, str) and actual.lower().startswith(expected.lower())
+        if op == "endswith":
+            return isinstance(actual, str) and isinstance(expected, str) and actual.lower().endswith(expected.lower())
+        if op == "gt":
+            return actual is not None and actual > expected
+        if op == "gte":
+            return actual is not None and actual >= expected
+        if op == "lt":
+            return actual is not None and actual < expected
+        if op == "lte":
+            return actual is not None and actual <= expected
+        if op == "between":
+            lo, hi = expected
+            return actual is not None and lo <= actual <= hi
+        if op == "in":
+            return actual in expected
+        if op == "istrue":
+            return bool(actual) is True
+        if op == "isfalse":
+            return bool(actual) is False
+        if op == "isnull":
+            return actual is None
+        return False
+
+    return [row for row in items if all(match(row, flt) for flt in filters)]
+
+
+def _apply_search(items: list[dict[str, Any]], query: str | None) -> list[dict[str, Any]]:
+    if not query:
+        return items
+    needle = query.strip().lower()
+    if not needle:
+        return items
+    return [row for row in items if any(isinstance(row.get(f), str) and needle in row[f].lower() for f in SEARCH_FIELDS)]
+
+
+def _parse_sort(sort: str | None) -> list[tuple[str, bool]]:
+    raw = sort or DEFAULT_SORT
+    order: list[tuple[str, bool]] = []
+    for chunk in [segment.strip() for segment in raw.split(";") if segment.strip()]:
+        parts = [piece.strip() for piece in chunk.split(",") if piece.strip()]
+        field = parts[0]
+        direction = parts[1].lower() if len(parts) > 1 else "asc"
+        if field not in FIELD_META or direction not in {"asc", "desc"}:
+            raise _error("Некорректная сортировка", details={"segment": chunk})
+        order.append((field, direction == "desc"))
+    if all(field != "id" for field, _ in order):
+        order.append(("id", False))
+    return order
+
+
+def _apply_sort(items: list[dict[str, Any]], order: list[tuple[str, bool]]) -> list[dict[str, Any]]:
+    result = list(items)
+    for field, desc in reversed(order):
+        result.sort(key=lambda row: row.get(field).lower() if isinstance(row.get(field), str) else row.get(field), reverse=desc)
+    return result
+
+
+def _paginate(items: list[dict[str, Any]], page: int, size: int) -> tuple[list[dict[str, Any]], int]:
+    total = len(items)
+    start = (page - 1) * size
+    end = start + size
+    return items[start:end], total
+
+
+def _find(product_id: int) -> int:
+    for idx, row in enumerate(_DATA):
+        if row["id"] == product_id:
+            return idx
+    raise _error("Товар не найден", details={"product_id": product_id})
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    _seed()
+
+
+@app.get("/products", response_model=PaginatedProducts)
+async def list_products(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    q: str | None = Query(None, description="Поисковая строка"),
+    filters: str | None = Query(None, description="JSON-массив фильтров"),
+    field: str | None = Query(None, description="Поле одиночного фильтра"),
+    operator: str | None = Query(None, description="Оператор одиночного фильтра"),
+    value: str | None = Query(None, description="Значение одиночного фильтра"),
+    sort: str | None = Query(None, description="Сортировка вида field,asc;field2,desc"),
+) -> PaginatedProducts:
+    normalized = _normalize_filters(filters, field, operator, value)
+    order = _parse_sort(sort)
+    with _LOCK:
+        snapshot = list(_DATA)
+    filtered = _apply_filters(snapshot, normalized)
+    searched = _apply_search(filtered, q)
+    ordered = _apply_sort(searched, order)
+    items, total = _paginate(ordered, page, page_size)
+    if page > 1 and not items:
+        raise _error("Страница вне диапазона", details={"page": page})
+    return PaginatedProducts(
+        items=[Product(**item) for item in items],
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=(total + page_size - 1) // page_size,
+        sort=";".join(f"{field},{'desc' if desc else 'asc'}" for field, desc in order),
+        filters=normalized,
+        q=q,
+    )
+
+
+@app.post("/products", response_model=Product, status_code=status.HTTP_201_CREATED)
+async def create_product(payload: ProductCreate = Body(...)) -> Product:
+    now = datetime.utcnow()
+    with _LOCK:
+        global _NEXT_ID
+        record = {
+            "id": _NEXT_ID,
+            "title": payload.title,
+            "category": payload.category,
+            "price": payload.price,
+            "stock": payload.stock,
+            "available": payload.available,
+            "description": payload.description,
+            "created_at": now,
+            "updated_at": now,
+        }
+        _DATA.append(record)
+        _NEXT_ID += 1
+    await manager.broadcast({"event": "product.created", "payload": record})
+    return Product(**record)
+
+
+@app.put("/products/{product_id}", response_model=Product)
+async def update_product(product_id: int, payload: ProductUpdate = Body(...)) -> Product:
+    with _LOCK:
+        index = _find(product_id)
+        record = _DATA[index]
+        updates = payload.model_dump(exclude_unset=True)
+        record.update(updates)
+        record["updated_at"] = datetime.utcnow()
+    await manager.broadcast({"event": "product.updated", "payload": record})
+    return Product(**record)
+
+
+@app.delete("/products/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_product(product_id: int) -> JSONResponse:
+    with _LOCK:
+        index = _find(product_id)
+        _DATA.pop(index)
+    await manager.broadcast({"event": "product.deleted", "payload": {"id": product_id}})
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+
+@app.websocket("/ws/products")
+async def products_socket(websocket: WebSocket) -> None:
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        await manager.disconnect(websocket)
+    except Exception:
+        await manager.disconnect(websocket)
+
+
+_seed()

--- a/frontend.jsx
+++ b/frontend.jsx
@@ -1,0 +1,439 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+const API_BASE_URL = window.__APP_CONFIG__?.apiBaseUrl || "http://localhost:8000";
+const DEFAULT_PAGE_SIZE = 20;
+
+const FIELDS = {
+  id: { label: "ID", type: "number" },
+  title: { label: "Название", type: "string" },
+  category: { label: "Категория", type: "string" },
+  price: { label: "Цена", type: "number" },
+  stock: { label: "Остаток", type: "number" },
+  available: { label: "В наличии", type: "boolean" },
+  description: { label: "Описание", type: "string", nullable: true },
+  created_at: { label: "Создан", type: "date" },
+  updated_at: { label: "Обновлён", type: "date" },
+};
+
+const OPERATORS = {
+  string: [
+    { value: "contains", label: "содержит" },
+    { value: "startswith", label: "начинается" },
+    { value: "endswith", label: "заканчивается" },
+    { value: "eq", label: "=" },
+    { value: "neq", label: "≠" },
+    { value: "in", label: "в списке" },
+  ],
+  stringNullable: [
+    { value: "contains", label: "содержит" },
+    { value: "startswith", label: "начинается" },
+    { value: "endswith", label: "заканчивается" },
+    { value: "eq", label: "=" },
+    { value: "neq", label: "≠" },
+    { value: "isnull", label: "пусто" },
+  ],
+  number: [
+    { value: "eq", label: "=" },
+    { value: "neq", label: "≠" },
+    { value: "gt", label: ">" },
+    { value: "gte", label: "≥" },
+    { value: "lt", label: "<" },
+    { value: "lte", label: "≤" },
+    { value: "between", label: "между" },
+    { value: "in", label: "в списке" },
+  ],
+  boolean: [
+    { value: "istrue", label: "истина" },
+    { value: "isfalse", label: "ложь" },
+    { value: "eq", label: "=" },
+    { value: "neq", label: "≠" },
+  ],
+  date: [
+    { value: "eq", label: "=" },
+    { value: "neq", label: "≠" },
+    { value: "gt", label: ">" },
+    { value: "gte", label: "≥" },
+    { value: "lt", label: "<" },
+    { value: "lte", label: "≤" },
+    { value: "between", label: "между" },
+  ],
+};
+
+const operatorLabel = Object.values(OPERATORS)
+  .flat()
+  .reduce((map, op) => ({ ...map, [op.value]: op.label }), {});
+
+function parseFilters(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && parsed.field) return [parsed];
+  } catch (error) {
+    console.warn("Invalid filters", error);
+  }
+  return [];
+}
+
+function parseSort(raw) {
+  if (!raw) return [{ field: "id", direction: "asc" }];
+  return raw
+    .split(";")
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const [field, direction = "asc"] = chunk.split(",");
+      return { field: field.trim(), direction: direction.trim().toLowerCase() === "desc" ? "desc" : "asc" };
+    })
+    .filter((entry) => FIELDS[entry.field]);
+}
+
+function formatSort(sort) {
+  return sort.map((entry) => `${entry.field},${entry.direction}`).join(";");
+}
+
+function parseUrlState() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    page: Math.max(1, Number.parseInt(params.get("page") ?? "1", 10)),
+    pageSize: Math.min(100, Math.max(1, Number.parseInt(params.get("page_size") ?? `${DEFAULT_PAGE_SIZE}`, 10))),
+    q: params.get("q") ?? "",
+    filters: parseFilters(params.get("filters")),
+    sort: params.get("sort") ?? "",
+  };
+}
+
+function buildQuery({ page, pageSize, q, filters, sort }) {
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  params.set("page_size", String(pageSize));
+  if (q) params.set("q", q);
+  if (filters.length) params.set("filters", JSON.stringify(filters));
+  if (sort) params.set("sort", sort);
+  return params.toString();
+}
+
+function debounce(value, delay) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+function normalizeValue(field, operator, value, extra) {
+  const type = FIELDS[field]?.type ?? "string";
+  const sanitize = (input) => {
+    if (input === undefined || input === null || (typeof input === "string" && !input.trim())) return null;
+    if (type === "number") {
+      const parsed = Number(input);
+      return Number.isNaN(parsed) ? null : parsed;
+    }
+    if (type === "boolean") {
+      if (typeof input === "boolean") return input;
+      const normalized = String(input).toLowerCase();
+      if (["true", "1", "yes", "да"].includes(normalized)) return true;
+      if (["false", "0", "no", "нет"].includes(normalized)) return false;
+      return null;
+    }
+    if (type === "date") {
+      const date = new Date(input);
+      return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    }
+    return String(input);
+  };
+
+  if (["istrue", "isfalse", "isnull"].includes(operator)) return { ok: true, value: null };
+  if (operator === "between") {
+    const first = sanitize(value);
+    const second = sanitize(extra);
+    return first !== null && second !== null ? { ok: true, value: [first, second] } : { ok: false, error: "Нужны два значения" };
+  }
+  if (operator === "in") {
+    const tokens = String(value ?? "")
+      .split(",")
+      .map((chunk) => chunk.trim())
+      .filter(Boolean);
+    if (!tokens.length) return { ok: false, error: "Список пуст" };
+    const converted = tokens.map(sanitize);
+    return converted.every((item) => item !== null) ? { ok: true, value: converted } : { ok: false, error: "Некорректное значение" };
+  }
+  const single = sanitize(value);
+  return single !== null ? { ok: true, value: single } : { ok: false, error: "Некорректное значение" };
+}
+
+function ProductsPage() {
+  const [urlState, setUrlState] = useState(parseUrlState);
+  const [search, setSearch] = useState(urlState.q);
+  const [draft, setDraft] = useState({ field: "title", operator: "contains", value: "", extra: "" });
+  const [filtersError, setFiltersError] = useState(null);
+  const [products, setProducts] = useState([]);
+  const [meta, setMeta] = useState({ total: 0, page: urlState.page, totalPages: 1 });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const initial = useRef(true);
+  const debouncedSearch = debounce(search, 350);
+
+  useEffect(() => {
+    const handler = () => setUrlState(parseUrlState());
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!initial.current) {
+      const query = buildQuery(urlState);
+      const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}`;
+      window.history.replaceState({}, "", nextUrl);
+    } else {
+      initial.current = false;
+    }
+    setSearch(urlState.q);
+  }, [urlState]);
+
+  useEffect(() => {
+    if (debouncedSearch !== urlState.q) {
+      setUrlState((prev) => ({ ...prev, page: 1, q: debouncedSearch }));
+    }
+  }, [debouncedSearch, urlState.q]);
+
+  const sortOrder = useMemo(() => parseSort(urlState.sort), [urlState.sort]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    const query = buildQuery(urlState);
+    fetch(`${API_BASE_URL}/products?${query}`, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.detail?.message || payload?.message || `Ошибка ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        setProducts(Array.from(new Map(data.items.map((item) => [item.id, item])).values()));
+        setMeta({ total: data.total, page: data.page, totalPages: data.total_pages });
+        setError(null);
+      })
+      .catch((err) => {
+        if (err.name !== "AbortError") setError(err.message);
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [urlState, reloadToken]);
+
+  useEffect(() => {
+    let closed = false;
+    let timeoutId;
+    const connect = () => {
+      const url = new URL("/ws/products", API_BASE_URL);
+      url.protocol = url.protocol.replace("http", "ws");
+      const ws = new WebSocket(url);
+      ws.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          if (["product.created", "product.updated", "product.deleted"].includes(payload?.event)) {
+            setReloadToken((value) => value + 1);
+          }
+        } catch (error) {
+          console.warn("WS payload error", error);
+        }
+      };
+      ws.onclose = () => {
+        if (!closed) timeoutId = setTimeout(connect, 3000);
+      };
+      ws.onerror = () => ws.close();
+      return ws;
+    };
+    const socket = connect();
+    return () => {
+      closed = true;
+      clearTimeout(timeoutId);
+      socket.close();
+    };
+  }, []);
+
+  const updateState = useCallback((updater) => {
+    setUrlState((prev) => {
+      const next = typeof updater === "function" ? updater(prev) : { ...prev, ...updater };
+      next.filters = (next.filters || []).filter(Boolean);
+      return next;
+    });
+  }, []);
+
+  const handleSort = (field) => {
+    updateState((prev) => {
+      const current = parseSort(prev.sort);
+      const index = current.findIndex((entry) => entry.field === field);
+      let next = [...current];
+      if (index === 0) {
+        next[0] = { field, direction: current[0].direction === "asc" ? "desc" : "asc" };
+      } else if (index > 0) {
+        next.splice(index, 1);
+        next.unshift({ field, direction: "asc" });
+      } else {
+        next.unshift({ field, direction: "asc" });
+      }
+      if (!next.length) next = [{ field: "id", direction: "asc" }];
+      return { ...prev, sort: formatSort(next), page: 1 };
+    });
+  };
+
+  const currentOperators = useMemo(() => {
+    const meta = FIELDS[draft.field];
+    if (!meta) return OPERATORS.string;
+    if (meta.type === "string" && meta.nullable) return OPERATORS.stringNullable;
+    if (meta.type === "string") return OPERATORS.string;
+    if (meta.type === "number") return OPERATORS.number;
+    if (meta.type === "boolean") return OPERATORS.boolean;
+    if (meta.type === "date") return OPERATORS.date;
+    return OPERATORS.string;
+  }, [draft.field]);
+
+  useEffect(() => {
+    if (!currentOperators.some((option) => option.value === draft.operator)) {
+      setDraft((prev) => ({ ...prev, operator: currentOperators[0]?.value ?? "contains", value: "", extra: "" }));
+    }
+  }, [currentOperators, draft.operator]);
+
+  const applyFilter = (event) => {
+    event.preventDefault();
+    const normalized = normalizeValue(draft.field, draft.operator, draft.value, draft.extra);
+    if (!normalized.ok) {
+      setFiltersError(normalized.error);
+      return;
+    }
+    setFiltersError(null);
+    updateState((prev) => ({
+      ...prev,
+      filters: [...prev.filters, { field: draft.field, operator: draft.operator, value: normalized.value }],
+      page: 1,
+    }));
+  };
+
+  const removeFilter = (index) => {
+    updateState((prev) => ({ ...prev, filters: prev.filters.filter((_, i) => i !== index), page: 1 }));
+  };
+
+  const clearFilters = () => updateState((prev) => ({ ...prev, filters: [], page: 1 }));
+
+  const changePage = (step) => updateState((prev) => ({ ...prev, page: Math.min(Math.max(prev.page + step, 1), meta.totalPages) }));
+
+  return (
+    <div className="products-app" style={{ fontFamily: "Inter, sans-serif", padding: "24px", maxWidth: "1100px", margin: "0 auto" }}>
+      <h1 style={{ fontSize: "22px", fontWeight: 600, marginBottom: "16px" }}>Товары</h1>
+      <section style={{ display: "flex", flexWrap: "wrap", gap: "12px", marginBottom: "16px" }}>
+        <div>
+          <label style={{ display: "block", fontSize: "12px", marginBottom: "4px" }}>Поиск</label>
+          <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Название, категория" style={{ padding: "8px", borderRadius: "6px", border: "1px solid #d0d5dd" }} />
+        </div>
+        <form onSubmit={applyFilter} style={{ display: "flex", gap: "8px", flexWrap: "wrap", alignItems: "flex-end" }}>
+          <div>
+            <label style={{ display: "block", fontSize: "12px", marginBottom: "4px" }}>Поле</label>
+            <select value={draft.field} onChange={(e) => setDraft({ field: e.target.value, operator: currentOperators[0]?.value ?? "contains", value: "", extra: "" })} style={{ padding: "8px", borderRadius: "6px", border: "1px solid #d0d5dd" }}>
+              {Object.entries(FIELDS).map(([value, meta]) => (
+                <option key={value} value={value}>
+                  {meta.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label style={{ display: "block", fontSize: "12px", marginBottom: "4px" }}>Оператор</label>
+            <select value={draft.operator} onChange={(e) => setDraft((prev) => ({ ...prev, operator: e.target.value, value: "", extra: "" }))} style={{ padding: "8px", borderRadius: "6px", border: "1px solid #d0d5dd" }}>
+              {currentOperators.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          {!['istrue', 'isfalse', 'isnull'].includes(draft.operator) && (
+            <div>
+              <label style={{ display: "block", fontSize: "12px", marginBottom: "4px" }}>Значение</label>
+              <input value={draft.value} onChange={(e) => setDraft((prev) => ({ ...prev, value: e.target.value }))} style={{ padding: "8px", borderRadius: "6px", border: "1px solid #d0d5dd" }} />
+            </div>
+          )}
+          {draft.operator === 'between' && (
+            <div>
+              <label style={{ display: "block", fontSize: "12px", marginBottom: "4px" }}>и</label>
+              <input value={draft.extra} onChange={(e) => setDraft((prev) => ({ ...prev, extra: e.target.value }))} style={{ padding: "8px", borderRadius: "6px", border: "1px solid #d0d5dd" }} />
+            </div>
+          )}
+          <button type="submit" style={{ padding: "9px 14px", background: "#2563eb", color: "#fff", borderRadius: "6px", border: "none", fontWeight: 600 }}>Добавить</button>
+        </form>
+      </section>
+      {filtersError && <div style={{ color: "#d92d20", marginBottom: "12px" }}>{filtersError}</div>}
+      {urlState.filters.length > 0 && (
+        <div style={{ marginBottom: "12px", display: "flex", gap: "8px", flexWrap: "wrap" }}>
+          {urlState.filters.map((filter, index) => (
+            <span key={`${filter.field}-${index}`} style={{ display: "inline-flex", gap: "6px", alignItems: "center", background: "#eef2ff", color: "#4338ca", padding: "4px 10px", borderRadius: "999px", fontSize: "13px" }}>
+              {FIELDS[filter.field]?.label ?? filter.field} {operatorLabel[filter.operator] ?? filter.operator} {Array.isArray(filter.value) ? filter.value.join(" – ") : filter.value ?? ""}
+              <button onClick={() => removeFilter(index)} style={{ border: "none", background: "transparent", color: "#4338ca", cursor: "pointer" }}>×</button>
+            </span>
+          ))}
+          <button onClick={clearFilters} style={{ border: "none", background: "transparent", color: "#2563eb", cursor: "pointer" }}>Очистить всё</button>
+        </div>
+      )}
+      <div style={{ border: "1px solid #e5e7eb", borderRadius: "10px", overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ background: "#f8fafc" }}>
+              {Object.keys(FIELDS).filter((key) => key !== "description").map((field) => {
+                const active = sortOrder.find((entry) => entry.field === field);
+                return (
+                  <th key={field} onClick={() => handleSort(field)} style={{ cursor: "pointer", padding: "10px", textAlign: "left", fontSize: "13px", color: "#475467" }}>
+                    {FIELDS[field].label} {active ? (active.direction === "asc" ? "▲" : "▼") : ""}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={7} style={{ padding: "20px", textAlign: "center" }}>Загрузка…</td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={7} style={{ padding: "20px", textAlign: "center", color: "#d92d20" }}>{error}</td>
+              </tr>
+            ) : products.length === 0 ? (
+              <tr>
+                <td colSpan={7} style={{ padding: "20px", textAlign: "center" }}>Нет данных</td>
+              </tr>
+            ) : (
+              products.map((product) => (
+                <tr key={product.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
+                  <td style={{ padding: "10px" }}>{product.id}</td>
+                  <td style={{ padding: "10px" }}>{product.title}</td>
+                  <td style={{ padding: "10px" }}>{product.category}</td>
+                  <td style={{ padding: "10px" }}>{product.price.toFixed(2)}</td>
+                  <td style={{ padding: "10px" }}>{product.stock}</td>
+                  <td style={{ padding: "10px" }}>{product.available ? "Да" : "Нет"}</td>
+                  <td style={{ padding: "10px" }}>{new Date(product.updated_at).toLocaleString()}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      <footer style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "12px" }}>
+        <span style={{ fontSize: "13px", color: "#475467" }}>Всего: {meta.total} · Стр. {meta.page} из {Math.max(meta.totalPages, 1)}</span>
+        <div style={{ display: "flex", gap: "8px" }}>
+          <button disabled={meta.page <= 1 || loading} onClick={() => changePage(-1)} style={{ padding: "8px 14px", borderRadius: "6px", border: "1px solid #d0d5dd", background: meta.page <= 1 || loading ? "#f9fafb" : "#fff" }}>Назад</button>
+          <button disabled={meta.page >= meta.totalPages || loading} onClick={() => changePage(1)} style={{ padding: "8px 14px", borderRadius: "6px", border: "1px solid #d0d5dd", background: meta.page >= meta.totalPages || loading ? "#f9fafb" : "#fff" }}>Вперёд</button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+const rootElement = document.getElementById("root");
+if (rootElement) {
+  createRoot(rootElement).render(<ProductsPage />);
+}


### PR DESCRIPTION
## Summary
- add an in-memory FastAPI backend with validated filtering, multi-field sorting, pagination, and websocket broadcasts for product events
- build a React products view that drives search, filters, and sorting from the URL, renders active filter chips, and refetches after websocket updates

## Testing
- python -m py_compile backend_main.py

------
https://chatgpt.com/codex/tasks/task_e_68dac9d8b6e0832fa99815e884ef2a20