### PR TITLE
feat: add deterministic product seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   ENABLE_MESSAGES=false
   ```
 - Новые миграции: `alembic revision -m "message" --autogenerate` и `alembic upgrade head`.
-- Сиды: `python -m app.db.seed` добавит 200 товаров и admin-аккаунт.
+- Сиды: `python -m app.db.seed` добавит 250 детерминированных товаров и admin-аккаунт. Подробнее в [docs/manual-product-testing.md](docs/manual-product-testing.md).
 
 ## 🔐 Аутентификация и RBAC
 - JWT access (15 минут) + refresh (7 дней).

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -2,20 +2,23 @@
 from __future__ import annotations
 
 import asyncio
-from decimal import Decimal
-from random import Random
+from decimal import Decimal, ROUND_HALF_UP
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.core.security import get_password_hash
 from app.db.session import AsyncSessionLocal
 from app.models.product import Product
 from app.models.user import User, UserRole
 
-RANDOM = Random(42)
+TOTAL_PRODUCTS = 250
+PRICE_MIN = Decimal("50.00")
+PRICE_MAX = Decimal("1500.00")
 
 
 async def seed_users(session):
+    """Ensure that the default admin account exists."""
+
     result = await session.execute(select(User).where(User.email == "admin@oppo.kz"))
     if not result.scalar_one_or_none():
         session.add(
@@ -28,22 +31,42 @@ async def seed_users(session):
         )
 
 
+def build_price(index: int) -> Decimal:
+    """Return a price evenly distributed across the configured range."""
+
+    if TOTAL_PRODUCTS == 1:
+        return PRICE_MIN
+    step = (PRICE_MAX - PRICE_MIN) / Decimal(TOTAL_PRODUCTS - 1)
+    raw_price = PRICE_MIN + step * Decimal(index)
+    return raw_price.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def build_stock_flag(index: int) -> bool:
+    """Distribute stock availability evenly between True/False values."""
+
+    return index % 2 == 0
+
+
 async def seed_products(session):
-    result = await session.execute(select(Product.id))
-    existing = result.scalars().count()
-    if existing >= 200:
+    """Populate the catalogue with deterministic mock products."""
+
+    result = await session.execute(select(func.count()).select_from(Product))
+    existing = int(result.scalar_one())
+    if existing >= TOTAL_PRODUCTS:
         return
-    for i in range(existing, 200):
+    for i in range(existing, TOTAL_PRODUCTS):
         session.add(
             Product(
-                title=f"Product {i+1}",
-                price=Decimal(str(RANDOM.uniform(10, 999))),
-                in_stock=RANDOM.choice([True, False]),
+                title=f"Demo Product {i + 1:03d}",
+                price=build_price(i),
+                in_stock=build_stock_flag(i),
             )
         )
 
 
 async def main() -> None:
+    """Entry point for the async seed runner."""
+
     async with AsyncSessionLocal() as session:
         await seed_users(session)
         await seed_products(session)

--- a/docs/manual-product-testing.md
+++ b/docs/manual-product-testing.md
@@ -1,0 +1,47 @@
+# Ручное тестирование списка товаров
+
+Этот чек-лист помогает наполнить каталог 250 детерминированными товарами и вручную проверить фильтры, сортировки и пагинацию API/интерфейса.
+
+## 1. Подготовка окружения
+1. Активируйте виртуальное окружение backend и установите зависимости:
+   ```bash
+   cd backend
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Примените миграции и запустите сидер с детерминированными данными:
+   ```bash
+   alembic upgrade head
+   python -m app.db.seed
+   ```
+3. Убедитесь, что в таблице `products` появилось ровно 250 записей. Быстрая проверка через psql/SQLite или REST:
+   ```bash
+   http GET :8000/api/v1/products/ Authorization:"Bearer <token>" size=1
+   ```
+   Ответ должен содержать `total = 250` и `sort.by = "id"`.
+
+## 2. Базовая sanity-проверка API
+1. Запустите backend:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+2. Залогиньтесь (UI или REST) под `admin@oppo.kz / Admin123!` и получите access token.
+3. Используйте Postman/HTTPie/браузер для следующих сценариев.
+
+## 3. Мини-сценарии ручных тестов
+1. **`contains` по названию** — GET `/api/v1/products?title_contains=Demo%20Product%20050`. Ожидайте ровно одну позицию `Demo Product 050`.
+2. **`between` по цене** — GET `/api/v1/products?price_between=200,400`. Убедитесь, что все цены лежат в диапазоне, а `total` > 0.
+3. **`in` по идентификаторам** — GET `/api/v1/products?id_in=1,2,3`. Проверьте, что вернулись именно товары `1-3` и `total = 3`.
+4. **Мульти-сортировка** — GET `/api/v1/products?sort_by=price,id&sort_order=desc,asc`. Убедитесь, что цена убывает, а при равенстве ID растёт.
+5. **Большие страницы** — GET `/api/v1/products?page=1&size=100`. Проверьте, что `size = 100`, `total = 250`, `next_offset = 100`.
+6. **Несовпадающий фильтр** — GET `/api/v1/products?title_contains=Nope`. Ожидайте `total = 0`, `items = []`, `filters_applied` сохранён.
+7. **Сброс фильтров** — Выполните предыдущий запрос, затем вызовите `/api/v1/products/reset` (или кнопка UI сброса). Список должен вернуться к 250 товарам.
+8. **Возврат на страницу 1 после смены фильтра** — Откройте `/api/v1/products?page=3&size=25`, затем примените фильтр `in_stock=false`. Проверьте, что ответ пришёл с `page = 1` и корректным `total` (125).
+9. **Ошибка на неверном операторе** — GET `/api/v1/products?price_foo=10`. Должен прийти `400` и `error_code = VALIDATION_ERROR`.
+10. **Стабильная дефолтная сортировка** — GET `/api/v1/products` без параметров дважды. Убедитесь, что порядок (по `id asc`) одинаков и `sort` содержит `{ "by": "id", "order": "asc" }`.
+
+## 4. Завершение
+- Для повторной чистой проверки можно очистить таблицу и снова запустить `python -m app.db.seed` — набор данных детерминированный.
+- При необходимости обновите access token через `/api/v1/auth/refresh`.
+
+Удачного тестирования!


### PR DESCRIPTION
## Motivation
- Prepare stable product fixtures for regression testing of listing filters.
- Document manual QA scenarios for product catalogue behaviour.

## Changes
- Updated `app.db.seed` to generate 250 deterministic products with evenly distributed prices and stock flags.
- Added a manual testing guide covering pagination, filters, sorts, and error scenarios.
- Linked the new guide from the README quickstart section.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

## Deployment / Rollout
- `cd backend && python -m app.db.seed` to backfill deterministic catalogue data after deploying.

## Checklist
- [x] No schema changes / migrations required.
- [x] Added/updated docs for QA and seeding process.
- [ ] CI green (pytest dependency missing locally).


------
https://chatgpt.com/codex/tasks/task_e_68dad24a4d44832fbdb1380581f4cd3b